### PR TITLE
feat: add .glowignore support for custom ignore patterns

### DIFF
--- a/ui/glowignore.go
+++ b/ui/glowignore.go
@@ -1,0 +1,33 @@
+package ui
+
+import (
+	"bufio"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// readGlowignore reads a .glowignore file from the given directory
+// and returns the patterns found. Returns an empty slice if the file
+// doesn't exist or can't be read.
+func readGlowignore(dir string) []string {
+	path := filepath.Join(dir, ".glowignore")
+	file, err := os.Open(path)
+	if err != nil {
+		return nil
+	}
+	defer file.Close()
+
+	var patterns []string
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		// Skip empty lines and comments
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		patterns = append(patterns, line)
+	}
+
+	return patterns
+}

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -385,7 +385,10 @@ func findLocalFiles(m commonModel) tea.Cmd {
 		if m.cfg.ShowAllFiles {
 			ch, err = gitcha.FindAllFilesExcept(cwd, markdownExtensions, nil)
 		} else {
-			ch, err = gitcha.FindFilesExcept(cwd, markdownExtensions, ignorePatterns(m))
+			// Combine default ignore patterns with .glowignore patterns
+			patterns := ignorePatterns(m)
+			patterns = append(patterns, readGlowignore(cwd)...)
+			ch, err = gitcha.FindFilesExcept(cwd, markdownExtensions, patterns)
 		}
 
 		if err != nil {


### PR DESCRIPTION
## Summary

- Add `.glowignore` file support for glow-specific exclusion patterns
- Patterns in `.glowignore` are combined with default ignore patterns
- Uses same syntax as `.gitignore` (one pattern per line, `#` for comments)

**Note:** `.gitignore` is already respected by the underlying `gitcha` library. This PR adds the ability to specify additional glow-specific exclusions.

## Changes

- `ui/glowignore.go` - New file to read and parse `.glowignore`
- `ui/ui.go` - Integrate `.glowignore` patterns into file discovery

## Example `.glowignore`

```
# Exclude vendor documentation
vendor/

# Exclude generated docs
docs/generated/

# Exclude specific files
CHANGELOG.md
```

Fixes #1

## Test Plan

- [x] Build succeeds
- [x] Existing tests pass
- [ ] Manual test: create `.glowignore` with patterns, verify files are excluded
- [ ] CI linting passes