### PR TITLE
feat: detect overly complex mermaid diagrams and skip ASCII rendering

### DIFF
--- a/EXAMPLE.md
+++ b/EXAMPLE.md
@@ -1,0 +1,58 @@
+# Mermaid Complexity Detection Example
+
+This file demonstrates how glow handles complex mermaid diagrams that exceed the ASCII renderer's capabilities.
+
+## Simple Diagram (renders correctly)
+
+```mermaid
+graph LR
+    A[Start] --> B{Decision}
+    B -->|Yes| C[OK]
+    B -->|No| D[Cancel]
+```
+
+## Complex Diagram (too complex for ASCII)
+
+The diagram below has multiple subgraphs with cross-subgraph edges, which causes layout issues in the mermaid-ascii library (node duplication, garbled output).
+
+```mermaid
+flowchart LR
+    subgraph SENSE[Sense]
+        cam[Camera]
+        unity[Unity]
+        tests[Tests]
+    end
+    subgraph PROCESS[Process]
+        perc[Perception]
+        backend[Backend]
+        commander[Commander]
+    end
+    subgraph CONTROL[Control]
+        gimbal[Gimbal]
+        servo[Servo]
+    end
+    subgraph OUTPUT[Output]
+        frontend[Frontend]
+        audio[Audio]
+    end
+
+    cam --> perc
+    cam --> backend
+    perc --> commander
+    unity --> commander
+    tests --> commander
+    backend --> commander
+    commander --> gimbal
+    gimbal --> servo
+    servo --> gimbal
+    backend --> frontend
+    commander --> audio
+```
+
+## Sequence Diagram (renders correctly)
+
+```mermaid
+sequenceDiagram
+    Client->>Server: Request
+    Server-->>Client: Response
+```

--- a/main.go
+++ b/main.go
@@ -310,7 +310,7 @@ func executeCLI(cmd *cobra.Command, src *source, w io.Writer) error {
 	}
 
 	// Preprocess mermaid diagrams before rendering
-	content = mermaid.ProcessMarkdown(content)
+	content = mermaid.ProcessMarkdown(content, int(width)) //nolint:gosec
 
 	out, err := r.Render(content)
 	if err != nil {

--- a/mermaid/mermaid.go
+++ b/mermaid/mermaid.go
@@ -9,18 +9,23 @@
 package mermaid
 
 import (
+	"errors"
 	"regexp"
 	"strings"
 
 	mermaidcmd "github.com/AlexanderGrooff/mermaid-ascii/cmd"
 )
 
+// ErrTooComplex is returned when a diagram is too complex for ASCII rendering.
+var ErrTooComplex = errors.New("diagram too complex for ASCII rendering")
+
 // Renderer defines the interface for rendering Mermaid diagrams.
 // This interface enables dependency injection for testing.
 type Renderer interface {
 	// Render converts a Mermaid diagram source to ASCII art.
 	// Returns the rendered output or an error if rendering fails.
-	Render(source string) (string, error)
+	// maxWidth specifies the maximum allowed output width (0 = no limit).
+	Render(source string, maxWidth int) (string, error)
 }
 
 // DefaultRenderer implements Renderer using the mermaid-ascii library.
@@ -32,9 +37,77 @@ func NewRenderer() *DefaultRenderer {
 }
 
 // Render converts a Mermaid diagram source to ASCII art using mermaid-ascii.
-func (r *DefaultRenderer) Render(source string) (string, error) {
+// Returns ErrTooComplex if the diagram is too complex or the output exceeds maxWidth.
+func (r *DefaultRenderer) Render(source string, maxWidth int) (string, error) {
+	if isTooComplex(source) {
+		return "", ErrTooComplex
+	}
 	// Pass nil config to use defaults (Unicode box-drawing characters)
-	return mermaidcmd.RenderDiagram(source, nil)
+	result, err := mermaidcmd.RenderDiagram(source, nil)
+	if err != nil {
+		return "", err
+	}
+
+	// Check if output exceeds max width
+	if maxWidth > 0 && getMaxLineWidth(result) > maxWidth {
+		return "", ErrTooComplex
+	}
+
+	return result, nil
+}
+
+// getMaxLineWidth returns the maximum line width in the given text.
+func getMaxLineWidth(text string) int {
+	maxWidth := 0
+	for _, line := range strings.Split(text, "\n") {
+		// Count runes for proper Unicode handling
+		width := len([]rune(line))
+		if width > maxWidth {
+			maxWidth = width
+		}
+	}
+	return maxWidth
+}
+
+// Complexity thresholds for flowcharts with subgraphs.
+// The mermaid-ascii library has layout issues with subgraphs that have
+// external connections, causing node duplication and garbled output.
+const (
+	maxSubgraphsWithEdges = 1  // Max subgraphs when diagram has cross-subgraph edges
+	maxEdgesWithSubgraphs = 6  // Max edges when subgraphs are present
+	maxTotalEdges         = 15 // Max edges for any flowchart
+)
+
+// Regex patterns for complexity detection
+var (
+	flowchartRegex = regexp.MustCompile(`(?i)^\s*(graph|flowchart)\s+(LR|RL|TD|TB|BT)`)
+	subgraphRegex  = regexp.MustCompile(`(?i)\bsubgraph\b`)
+	edgeRegex      = regexp.MustCompile(`-->|--[^>]|-.->|-\.-|==>|~~~|&`)
+)
+
+// isTooComplex checks if a diagram is too complex for the ASCII renderer.
+// Flowcharts with multiple subgraphs and cross-subgraph edges render poorly
+// due to node duplication bugs in the mermaid-ascii library.
+func isTooComplex(source string) bool {
+	// Only apply complexity checks to flowcharts
+	if !flowchartRegex.MatchString(source) {
+		return false
+	}
+
+	subgraphCount := len(subgraphRegex.FindAllString(source, -1))
+	edgeCount := len(edgeRegex.FindAllString(source, -1))
+
+	// Too many edges overall
+	if edgeCount > maxTotalEdges {
+		return true
+	}
+
+	// Subgraphs with significant edges cause layout issues
+	if subgraphCount > maxSubgraphsWithEdges && edgeCount > maxEdgesWithSubgraphs {
+		return true
+	}
+
+	return false
 }
 
 // codeBlockRegex matches fenced code blocks with mermaid language identifier.
@@ -44,16 +117,22 @@ var codeBlockRegex = regexp.MustCompile("(?s)```mermaid\\s*\n(.*?)```|~~~mermaid
 // Preprocessor handles preprocessing of markdown to render Mermaid diagrams.
 type Preprocessor struct {
 	renderer Renderer
+	maxWidth int
 }
 
 // NewPreprocessor creates a new Preprocessor with the given renderer.
-func NewPreprocessor(renderer Renderer) *Preprocessor {
-	return &Preprocessor{renderer: renderer}
+// maxWidth specifies the maximum allowed output width (0 = no limit).
+func NewPreprocessor(renderer Renderer, maxWidth int) *Preprocessor {
+	return &Preprocessor{renderer: renderer, maxWidth: maxWidth}
 }
+
+// tooComplexNote is shown when a diagram cannot be rendered in ASCII.
+const tooComplexNote = "  ⚠ [Diagram too complex for terminal - view in markdown renderer]"
 
 // Process finds and renders all Mermaid code blocks in the given markdown.
 // Returns the markdown with Mermaid blocks replaced by their ASCII rendering.
 // If rendering fails for a block, it is left unchanged with an error comment.
+// If a diagram is too complex, it shows the original source with a note.
 func (p *Preprocessor) Process(markdown string) string {
 	return codeBlockRegex.ReplaceAllStringFunc(markdown, func(match string) string {
 		// Extract the diagram source from the code block
@@ -63,8 +142,12 @@ func (p *Preprocessor) Process(markdown string) string {
 		}
 
 		// Render the diagram
-		rendered, err := p.renderer.Render(source)
+		rendered, err := p.renderer.Render(source, p.maxWidth)
 		if err != nil {
+			if errors.Is(err, ErrTooComplex) {
+				// Show original source with a visual cue
+				return tooComplexNote + "\n" + match
+			}
 			// If rendering fails, keep the original code block with an error note
 			return match + "\n<!-- mermaid rendering error: " + err.Error() + " -->"
 		}
@@ -91,7 +174,8 @@ func extractDiagramSource(block string) string {
 }
 
 // ProcessMarkdown is a convenience function that processes markdown with the default renderer.
-func ProcessMarkdown(markdown string) string {
-	p := NewPreprocessor(NewRenderer())
+// maxWidth specifies the maximum allowed output width (0 = no limit).
+func ProcessMarkdown(markdown string, maxWidth int) string {
+	p := NewPreprocessor(NewRenderer(), maxWidth)
 	return p.Process(markdown)
 }

--- a/ui/pager.go
+++ b/ui/pager.go
@@ -451,7 +451,7 @@ func glamourRender(m pagerModel, markdown string) (string, error) {
 	}
 
 	// Preprocess mermaid diagrams before rendering
-	markdown = mermaid.ProcessMarkdown(markdown)
+	markdown = mermaid.ProcessMarkdown(markdown, width)
 
 	out, err := r.Render(markdown)
 	if err != nil {


### PR DESCRIPTION
## Summary

- Adds complexity detection for mermaid diagrams that would render poorly in ASCII
- Shows original mermaid source with a visual warning (⚠) when a diagram is too complex
- Validates rendered output width against terminal width to prevent overflow

## Problem

The mermaid-ascii library has layout limitations:
- Flowcharts with multiple subgraphs and cross-subgraph edges cause node duplication
- Complex diagrams produce extremely wide output (300+ chars) that exceeds terminal width

## Solution

Complexity heuristics detect problematic diagrams before/after rendering:
- Pre-render: Checks subgraph count and edge count for flowcharts
- Post-render: Validates output width against terminal width

When a diagram is too complex, glow displays:
```
⚠ [Diagram too complex for terminal - view in markdown renderer]
```mermaid
flowchart LR
    ...original source...
```
```

Users can copy the source and view it in GitHub, VSCode, or other markdown renderers.

## Test plan

- [x] Unit tests for complexity detection (`TestIsTooComplex`)
- [x] Unit test for the exact EXAMPLE.md diagram (`TestComplexDiagramFromEXAMPLE`)
- [x] Unit tests for width limit enforcement (`TestWidthLimitEnforcement`)
- [x] Unit test for visual cue output (`TestTooComplexShowsOriginalWithNote`)
- [x] Manual testing with `./glow EXAMPLE.md`