### PR TITLE
refactor: introduce Terminal interface for testability via DI

### DIFF
--- a/ui/outline_test.go
+++ b/ui/outline_test.go
@@ -226,9 +226,10 @@ func TestOutlineModelUpdateCurrent(t *testing.T) {
 func TestPagerOutlineIntegration(t *testing.T) {
 	// Test that outline works correctly when toggled
 	common := &commonModel{
-		cfg:    Config{ShowOutline: false},
-		width:  120,
-		height: 40,
+		cfg:      Config{ShowOutline: false},
+		terminal: NewTestTerminal(),
+		width:    120,
+		height:   40,
 	}
 
 	m := newPagerModel(common)
@@ -271,9 +272,10 @@ func TestPagerOutlineIntegration(t *testing.T) {
 
 func TestPagerIsMarkdownFile(t *testing.T) {
 	common := &commonModel{
-		cfg:    Config{},
-		width:  120,
-		height: 40,
+		cfg:      Config{},
+		terminal: NewTestTerminal(),
+		width:    120,
+		height:   40,
 	}
 
 	tests := []struct {
@@ -336,9 +338,10 @@ func TestOutlineViewRendering(t *testing.T) {
 
 func TestPagerViewWithOutline(t *testing.T) {
 	common := &commonModel{
-		cfg:    Config{ShowOutline: true},
-		width:  100,
-		height: 25,
+		cfg:      Config{ShowOutline: true},
+		terminal: NewTestTerminal(),
+		width:    100,
+		height:   25,
 	}
 
 	m := newPagerModel(common)
@@ -379,9 +382,10 @@ func TestPagerViewWithOutline(t *testing.T) {
 
 func TestPagerViewWithANSIContent(t *testing.T) {
 	common := &commonModel{
-		cfg:    Config{ShowOutline: true},
-		width:  100,
-		height: 25,
+		cfg:      Config{ShowOutline: true},
+		terminal: NewTestTerminal(),
+		width:    100,
+		height:   25,
 	}
 
 	m := newPagerModel(common)
@@ -426,9 +430,10 @@ func TestPagerViewWithHighPerfRendering(t *testing.T) {
 	}
 
 	common := &commonModel{
-		cfg:    config,
-		width:  100,
-		height: 25,
+		cfg:      config,
+		terminal: NewTestTerminal(),
+		width:    100,
+		height:   25,
 	}
 
 	m := newPagerModel(common)

--- a/ui/pager.go
+++ b/ui/pager.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/atotto/clipboard"
 	"github.com/charmbracelet/bubbles/viewport"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/glamour"
@@ -19,7 +18,6 @@ import (
 	runewidth "github.com/mattn/go-runewidth"
 	"github.com/muesli/reflow/ansi"
 	"github.com/muesli/reflow/truncate"
-	"github.com/muesli/termenv"
 )
 
 const (
@@ -267,9 +265,9 @@ func (m pagerModel) update(msg tea.Msg) (pagerModel, tea.Cmd) {
 
 		case "c":
 			// Copy using OSC 52
-			termenv.Copy(m.currentDocument.Body)
+			m.common.terminal.CopyOSC52(m.currentDocument.Body)
 			// Copy using native system clipboard
-			_ = clipboard.WriteAll(m.currentDocument.Body)
+			_ = m.common.terminal.CopyClipboard(m.currentDocument.Body)
 			cmds = append(cmds, m.showStatusMessage(pagerStatusMessage{"Copied contents", false}))
 
 		case "r":

--- a/ui/terminal.go
+++ b/ui/terminal.go
@@ -1,0 +1,44 @@
+package ui
+
+import (
+	"github.com/atotto/clipboard"
+	"github.com/muesli/termenv"
+)
+
+// Terminal abstracts terminal I/O operations for testability.
+// This interface allows injecting test doubles that don't require
+// an actual terminal.
+type Terminal interface {
+	// HasDarkBackground returns true if the terminal has a dark background.
+	// Used to select appropriate color schemes.
+	HasDarkBackground() bool
+
+	// CopyOSC52 copies the given string to the clipboard using OSC 52
+	// escape sequences. This works over SSH and in terminals that support it.
+	CopyOSC52(s string)
+
+	// CopyClipboard copies the given string to the native system clipboard.
+	// Returns an error if clipboard access fails.
+	CopyClipboard(s string) error
+}
+
+// RealTerminal implements Terminal using actual terminal operations.
+type RealTerminal struct{}
+
+// HasDarkBackground returns true if the terminal has a dark background.
+func (RealTerminal) HasDarkBackground() bool {
+	return termenv.HasDarkBackground()
+}
+
+// CopyOSC52 copies the string to clipboard using OSC 52 escape sequences.
+func (RealTerminal) CopyOSC52(s string) {
+	termenv.Copy(s)
+}
+
+// CopyClipboard copies the string to the native system clipboard.
+func (RealTerminal) CopyClipboard(s string) error {
+	return clipboard.WriteAll(s)
+}
+
+// Ensure RealTerminal implements Terminal.
+var _ Terminal = RealTerminal{}

--- a/ui/terminal_test.go
+++ b/ui/terminal_test.go
@@ -1,0 +1,175 @@
+package ui
+
+import (
+	"errors"
+	"testing"
+)
+
+// TestTerminal is a test double for Terminal that records calls
+// and allows configuring return values.
+type TestTerminal struct {
+	// Configuration
+	DarkBackground   bool
+	ClipboardError   error
+	ClipboardContent string
+
+	// Call tracking
+	OSC52Calls     []string
+	ClipboardCalls []string
+}
+
+// NewTestTerminal creates a TestTerminal with default settings
+// (light background, no clipboard errors).
+func NewTestTerminal() *TestTerminal {
+	return &TestTerminal{
+		DarkBackground: false,
+		ClipboardError: nil,
+	}
+}
+
+// HasDarkBackground returns the configured DarkBackground value.
+func (t *TestTerminal) HasDarkBackground() bool {
+	return t.DarkBackground
+}
+
+// CopyOSC52 records the copy call for later assertion.
+func (t *TestTerminal) CopyOSC52(s string) {
+	t.OSC52Calls = append(t.OSC52Calls, s)
+}
+
+// CopyClipboard records the copy call and returns the configured error.
+func (t *TestTerminal) CopyClipboard(s string) error {
+	t.ClipboardCalls = append(t.ClipboardCalls, s)
+	if t.ClipboardError == nil {
+		t.ClipboardContent = s
+	}
+	return t.ClipboardError
+}
+
+// Ensure TestTerminal implements Terminal.
+var _ Terminal = (*TestTerminal)(nil)
+
+func TestTestTerminal_HasDarkBackground(t *testing.T) {
+	tests := []struct {
+		name     string
+		dark     bool
+		expected bool
+	}{
+		{"dark background", true, true},
+		{"light background", false, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			term := &TestTerminal{DarkBackground: tt.dark}
+			if got := term.HasDarkBackground(); got != tt.expected {
+				t.Errorf("HasDarkBackground() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestTestTerminal_CopyOSC52(t *testing.T) {
+	term := NewTestTerminal()
+
+	term.CopyOSC52("hello")
+	term.CopyOSC52("world")
+
+	if len(term.OSC52Calls) != 2 {
+		t.Errorf("expected 2 OSC52 calls, got %d", len(term.OSC52Calls))
+	}
+	if term.OSC52Calls[0] != "hello" {
+		t.Errorf("first call = %q, want %q", term.OSC52Calls[0], "hello")
+	}
+	if term.OSC52Calls[1] != "world" {
+		t.Errorf("second call = %q, want %q", term.OSC52Calls[1], "world")
+	}
+}
+
+func TestTestTerminal_CopyClipboard(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		term := NewTestTerminal()
+
+		err := term.CopyClipboard("test content")
+
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if term.ClipboardContent != "test content" {
+			t.Errorf("ClipboardContent = %q, want %q", term.ClipboardContent, "test content")
+		}
+		if len(term.ClipboardCalls) != 1 {
+			t.Errorf("expected 1 clipboard call, got %d", len(term.ClipboardCalls))
+		}
+	})
+
+	t.Run("error", func(t *testing.T) {
+		term := NewTestTerminal()
+		term.ClipboardError = errors.New("clipboard unavailable")
+
+		err := term.CopyClipboard("test content")
+
+		if err == nil {
+			t.Error("expected error, got nil")
+		}
+		if term.ClipboardContent != "" {
+			t.Errorf("ClipboardContent should be empty on error, got %q", term.ClipboardContent)
+		}
+	})
+}
+
+func TestRealTerminal_ImplementsInterface(t *testing.T) {
+	// This test verifies RealTerminal implements Terminal at compile time.
+	// The actual var _ Terminal = RealTerminal{} in terminal.go does this,
+	// but this test makes it explicit.
+	var term Terminal = RealTerminal{}
+	_ = term
+}
+
+func TestNewModelWithTerminal_DarkBackground(t *testing.T) {
+	term := &TestTerminal{DarkBackground: true}
+	cfg := Config{GlamourStyle: "auto"}
+
+	model := newModelWithTerminal(cfg, "", term).(model)
+
+	// When terminal has dark background, style should be set to dark
+	if model.common.cfg.GlamourStyle != "dark" {
+		t.Errorf("GlamourStyle = %q, want %q for dark background", model.common.cfg.GlamourStyle, "dark")
+	}
+}
+
+func TestNewModelWithTerminal_LightBackground(t *testing.T) {
+	term := &TestTerminal{DarkBackground: false}
+	cfg := Config{GlamourStyle: "auto"}
+
+	model := newModelWithTerminal(cfg, "", term).(model)
+
+	// When terminal has light background, style should be set to light
+	if model.common.cfg.GlamourStyle != "light" {
+		t.Errorf("GlamourStyle = %q, want %q for light background", model.common.cfg.GlamourStyle, "light")
+	}
+}
+
+func TestNewModelWithTerminal_ExplicitStyle(t *testing.T) {
+	term := &TestTerminal{DarkBackground: true}
+	cfg := Config{GlamourStyle: "dracula"} // Explicit style, not "auto"
+
+	model := newModelWithTerminal(cfg, "", term).(model)
+
+	// When an explicit style is set, it should be preserved
+	if model.common.cfg.GlamourStyle != "dracula" {
+		t.Errorf("GlamourStyle = %q, want %q for explicit style", model.common.cfg.GlamourStyle, "dracula")
+	}
+}
+
+func TestNewModelWithTerminal_TerminalInjection(t *testing.T) {
+	term := NewTestTerminal()
+	cfg := Config{}
+
+	model := newModelWithTerminal(cfg, "", term).(model)
+
+	// Verify the terminal is properly injected into commonModel
+	if model.common.terminal != term {
+		t.Error("terminal was not properly injected into commonModel")
+	}
+}


### PR DESCRIPTION
## Summary
Introduces a `Terminal` interface that abstracts terminal I/O operations, enabling TUI components to be tested without a real terminal. This is the first step toward full rendering testability as described in issue #16.

## Changes
- **New `ui/terminal.go`**: Defines `Terminal` interface with `HasDarkBackground()`, `CopyOSC52()`, and `CopyClipboard()` methods, plus `RealTerminal` production implementation
- **New `ui/terminal_test.go`**: Adds `TestTerminal` test double and comprehensive tests including model injection tests
- **`ui/ui.go`**: 
  - Added `terminal` field to `commonModel`
  - New `NewProgramWithTerminal()` composition root for DI
  - New `newModelWithTerminal()` for terminal injection
  - Theme detection now uses injected terminal
- **`ui/pager.go`**: Clipboard operations now use injected terminal
- **`ui/outline_test.go`**: Updated existing tests to use `TestTerminal`

## Testing
- [x] All existing tests pass
- [x] New tests verify DI works correctly
- [x] `go vet` passes
- [x] `go build` succeeds

## Design Notes
- Follows hexagonal architecture with manual DI at the composition root
- `NewProgram()` remains backwards-compatible, using `RealTerminal{}` by default
- Test double (`TestTerminal`) records calls for assertion and allows configuring return values

Fixes #16